### PR TITLE
Support for meta name generator

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -55,6 +55,7 @@ func prettyspector(mi *metainspector.MetaInspector, a bool) {
 	sprintIfExists("Title", mi.Title())
 	sprintIfExists("Author", mi.Author())
 	sprintIfExists("Description", mi.Description())
+	sprintIfExists("Generator", mi.Generator())
 	sprintIfExists("Charset", mi.Charset())
 	sprintIfExists("Language", mi.Language())
 	sprintIfExists("Feed URL", mi.Feed())

--- a/metainspector/metainspector.go
+++ b/metainspector/metainspector.go
@@ -40,6 +40,7 @@ type MetaInspector struct {
 	language      string
 	author        string
 	description   string
+	generator     string
 	feed          string
 	charset       string
 	links         []string
@@ -72,6 +73,7 @@ func New(uri string) (*MetaInspector, error) {
 		scraper.language,
 		scraper.author,
 		scraper.description,
+		scraper.generator,
 		scraper.feed,
 		scraper.charset,
 		scraper.links,
@@ -118,6 +120,11 @@ func (m MetaInspector) Author() string {
 // Description of the site
 func (m MetaInspector) Description() string {
 	return m.description
+}
+
+// Generator of the site
+func (m MetaInspector) Generator() string {
+	return m.generator
 }
 
 // Feed link of the site

--- a/metainspector/scraper.go
+++ b/metainspector/scraper.go
@@ -15,6 +15,7 @@ type scraper struct {
 	language      string
 	author        string
 	description   string
+	generator     string
 	feed          string
 	charset       string
 	links         []string
@@ -89,6 +90,7 @@ func newScraper(u *url.URL, timeout int) (*scraper, error) {
 	var language string
 	var author string
 	var description string
+	var generator string
 	var feed string
 	charset := "utf-8"
 	links := make([]string, 0)
@@ -121,6 +123,8 @@ func newScraper(u *url.URL, timeout int) (*scraper, error) {
 				keywords = strings.Split(findAttribute(n, "content"), ", ")
 			case "description":
 				description = findAttribute(n, "content")
+			case "generator":
+				generator = findAttribute(n, "content")
 			}
 
 			httpEquiv := findAttribute(n, "http-equiv")
@@ -155,6 +159,7 @@ func newScraper(u *url.URL, timeout int) (*scraper, error) {
 		language,
 		author,
 		description,
+		generator,
 		feed,
 		charset,
 		links,


### PR DESCRIPTION
I needed support for generator, if you find it useful here is a pull request.

```
$ ./cmd -all -u="en.wikipedia.org"
----> Title: Wikipedia, the free encyclopedia
----> Generator: MediaWiki 1.22wmf3
----> Charset: utf-8
----> Language: en
----> Links: ....
```
